### PR TITLE
Run integrationtests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,19 @@
 language: java
+dist: trusty
+sudo: true
 jdk:
   - oraclejdk8
   - oraclejdk9
+addons:
+  firefox: latest # https://docs.travis-ci.com/user/firefox
+  chrome: stable # https://docs.travis-ci.com/user/chrome
 install:
   - ./mvnw test-compile -DskipTests
+before_script:
+  # https://docs.travis-ci.com/user/gui-and-headless-browsers/
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
+  - sleep 3 # give xvfb some time to start
 script:
   - ./mvnw test integration-test jacoco:report
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
 install:
   - ./mvnw test-compile -DskipTests
 script:
-  - ./mvnw test jacoco:report
+  - ./mvnw test integration-test jacoco:report
 after_success:
   - ./mvnw coveralls:report
 notifications:

--- a/src/test/java/com/github/nscuro/wdm/binary/BinaryManagerImplIT.java
+++ b/src/test/java/com/github/nscuro/wdm/binary/BinaryManagerImplIT.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 class BinaryManagerImplIT {
 
@@ -30,6 +31,8 @@ class BinaryManagerImplIT {
         @ParameterizedTest
         @EnumSource(Browser.class)
         void testGetLatestBinaryForCurrentOsAndArchitecture(final Browser browser) throws IOException {
+            assumeTrue(browser.doesRequireBinary());
+
             downloadedFile = binaryManager.getBinary(browser);
 
             assertThat(downloadedFile).exists();


### PR DESCRIPTION
Additional to the code changes, Travis' "Build branch updates"-option has been disabled to reduce the load on it's system as the integration tests perform a lot of downloading.

There's still a cron job running every week and pull-request updates are also still being built though.